### PR TITLE
Bump undici to 6.27.0/7.28.0 (GHSA-vxpw-j846-p89q, alert #119)

### DIFF
--- a/client/base/yarn.lock
+++ b/client/base/yarn.lock
@@ -3938,16 +3938,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 
 "undici@npm:^7.19.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 

--- a/client/landing/yarn.lock
+++ b/client/landing/yarn.lock
@@ -3463,8 +3463,8 @@ __metadata:
 
 "silverstripe-search-admin@file:../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz::locator=landing%40workspace%3A.":
   version: 1.0.0
-  resolution: "silverstripe-search-admin@file:../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz#../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz::hash=625cb7&locator=landing%40workspace%3A."
-  checksum: 10c0/f17787a56faea5958e3635020a4b88c86702c64cbe5244f49359040fe4a9ed203f0a870b4b7901eec03ddd53af513e940628962f401c6f944612c3efd521a8e3
+  resolution: "silverstripe-search-admin@file:../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz#../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz::hash=90456d&locator=landing%40workspace%3A."
+  checksum: 10c0/d87ae18a2256b329dc397a60772eaf724999cedd8a31b1d4ac1e7bbc4257bf96d922bb3d11e18443a17de353810d7c35949091a01446260a52414d545bd4a998
   languageName: node
   linkType: hard
 
@@ -3686,16 +3686,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 
 "undici@npm:^7.19.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 

--- a/client/synonyms/yarn.lock
+++ b/client/synonyms/yarn.lock
@@ -3551,8 +3551,8 @@ __metadata:
 
 "silverstripe-search-admin@file:../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz::locator=synonyms%40workspace%3A.":
   version: 1.0.0
-  resolution: "silverstripe-search-admin@file:../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz#../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz::hash=625cb7&locator=synonyms%40workspace%3A."
-  checksum: 10c0/f17787a56faea5958e3635020a4b88c86702c64cbe5244f49359040fe4a9ed203f0a870b4b7901eec03ddd53af513e940628962f401c6f944612c3efd521a8e3
+  resolution: "silverstripe-search-admin@file:../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz#../base/dist/emulator/silverstripe-search-admin-1.0.0.tgz::hash=90456d&locator=synonyms%40workspace%3A."
+  checksum: 10c0/d87ae18a2256b329dc397a60772eaf724999cedd8a31b1d4ac1e7bbc4257bf96d922bb3d11e18443a17de353810d7c35949091a01446260a52414d545bd4a998
   languageName: node
   linkType: hard
 
@@ -3779,16 +3779,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 
 "undici@npm:^7.19.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Bumps the transitive `undici` dependency past the patched floors in all three client pilet lockfiles:

| Lockfile | undici 6.x | undici 7.x |
|---|---|---|
| `client/base/yarn.lock` | 6.25.0 → **6.27.0** | 7.25.0 → **7.28.0** |
| `client/landing/yarn.lock` | 6.25.0 → **6.27.0** | 7.25.0 → **7.28.0** |
| `client/synonyms/yarn.lock` | 6.25.0 → **6.27.0** | 7.25.0 → **7.28.0** |

## Why

Resolves Dependabot **alert #119** — GHSA-vxpw-j846-p89q / CVE-2026-12151 (high, CWE-400), a DoS in undici's WebSocket client via unbounded fragment count.

**Not exploitable at runtime in this module:** `undici` is a build-time-only transitive dep (pulled via `cheerio` and `node-gyp`, both under `devDependencies` of the piral/esbuild toolchain). It is a Node-only library and is **not** bundled into the shipped `dist/` assets (`grep` finds zero references). The CVE additionally requires the WebSocket *client* to connect to an attacker-controlled endpoint, which the build never does. Bumping anyway to clear the alert.

The alert names `client/synonyms`, but `base` and `landing` carried the identical pin and would surface as sibling alerts, so all three are bumped.

## How

`yarn up -R undici --mode=update-lockfile` in each client dir — lockfile-only, dependency ranges unchanged, just re-resolved to the newest in-range versions.

## Testing

All three pilets build cleanly (`yarn build`): base ✔, synonyms ✔, landing ✔. dist output is unchanged by the bump (undici is not in the bundle), so no built artifacts are included in this PR.